### PR TITLE
Add build entry with python 3.9.7-alpine3.14, pandas 1.4.1

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,8 +1,17 @@
 # template version 2022.1
 
 services:
-  build:
+  build_3.10.2-alpine3.15:
     image: python:3.10.2-alpine3.15
+    working_dir: /workspace
+    entrypoint:
+      - /bin/sh
+      - build.sh
+    volumes:
+      - ./:/workspace
+
+  build_3.9.7-alpine3.14:
+    image: python:3.9.7-alpine3.14
     working_dir: /workspace
     entrypoint:
       - /bin/sh


### PR DESCRIPTION
Hi, this PR is all about support wheel which is build with python version 3.9.7.
The build process use a docker image named python:3.9.7-alpine3.14

the output process should give us two files:
- pandas-1.4.1-cp310-cp310-linux_x86_64.whl
- pandas-1.4.1-cp39-cp39-linux_x86_64.whl

